### PR TITLE
Removed an erronious function that was left over from a debug

### DIFF
--- a/src/Asakusuma/SugarWrapper/Rest.php
+++ b/src/Asakusuma/SugarWrapper/Rest.php
@@ -277,10 +277,6 @@ class Rest
         return FALSE;
     }
 
-    private function test(){
-        $this->get_
-    }
-
     /**
      * Retrieves Sugar Bean records. Essentially returns the result of a
      * SELECT SQL statement, given a base module, any number of related of modules,


### PR DESCRIPTION
Forgot to remove this function before my previous pull request.

It causes a syntax error and causes the class to not load
