### PR TITLE
Fixing a big with set_entry response continue.

### DIFF
--- a/src/Asakusuma/SugarWrapper/Rest.php
+++ b/src/Asakusuma/SugarWrapper/Rest.php
@@ -266,6 +266,9 @@ class Rest
                 'rest_data' => json_encode($call_arguments)
             )
         );
+        if($call_name == 'set_entry') {
+            $request->addHeaders(array('Expect'=>' '));
+        }
 
         $output = $request->post();
         $response_data = json_decode(html_entity_decode($output['body']), true);


### PR DESCRIPTION
SugarCRMs set_entry function returns a response like so:

HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Date: Wed, 23 Apr 2014 15:02:32 GMT

That Continue response will break AlexSoft's curl function on this line:
list($responseParts['headersString'], $responseParts['body']) = explode("\r\n\r\n", $this->_response, 2);

This will dump everything, including the HTTP/1.1 200 OK and all other server headers into the output body(where only json should be), thereby breaking the json_decode function. I've added a workaround to fix this by sending an empty expect to circumvent the 100.
