### PR TITLE
Add set_document_revision method

### DIFF
--- a/src/Asakusuma/SugarWrapper/Rest.php
+++ b/src/Asakusuma/SugarWrapper/Rest.php
@@ -639,6 +639,36 @@ class Rest
 
         return $result;
     }
+    
+    /**
+	  * Upload file to Sugar Document
+	  * 
+	  * @param string $docID the document ID the file should be attached to
+	  * @param string $filename the file name 
+	  * @param string $path the full path of the file
+	  * @param string $revision the revision number of the file
+	  * @return array
+	  */
+	 
+	 public function set_document_revision($docID, $filename, $path, $revision) {
+		 $call_arguments = array(
+		 	'session' => $this->session,
+			'document_revision' => array(
+			'id' => $docID,
+			'revision' => $revision,
+			'filename' => $filename,
+			'file' => base64_encode(file_get_contents($path)),
+			),
+    	);
+		
+		
+        $result = $this->rest_request(
+            'set_document_revision',
+            $call_arguments
+        );
+		
+        return $result;
+	 }
 
     /**
      * Retrieve the list of available modules on the system available to the


### PR DESCRIPTION
Currently the wrapper has no way of uploading files to the documents module. You can create note attachments, but you can't actually upload files. 

This fixes that using the set_document_revision parameter. 

This is my first time forking and creating a pull request. I apologize if I messed something up. 